### PR TITLE
Analyze recording button visibility issue

### DIFF
--- a/RECORDING_BUTTON_BUG_ANALYSIS.md
+++ b/RECORDING_BUTTON_BUG_ANALYSIS.md
@@ -1,0 +1,103 @@
+# Recording Button Bug Analysis
+
+## Bug Description
+The recording button (voice recording functionality) is not visible in the dashboard view when users are authenticated and on the inventory tab.
+
+## Root Cause Analysis
+
+### Primary Issue
+The `onAddItem` prop is **missing** from the `InventoryDashboard` component call in `src/pages/Index.tsx`.
+
+### Code Flow Analysis
+
+1. **Entry Point**: `src/pages/Index.tsx` (lines 544-553)
+   ```tsx
+   <InventoryDashboard
+     foodItems={foodItems}
+     onRemoveItem={removeFoodItem}
+     onEditItem={setEditingItem}
+     userId={user.id}
+     onNavigateToSettings={() => setActiveTab('settings')}
+     recentActions={recentActions}
+     historyLoading={historyLoading}
+     refetchHistory={refetchHistory}
+   />
+   ```
+   **Missing**: `onAddItem={addFoodItem}` prop
+
+2. **Dashboard Component**: `src/components/InventoryDashboard.tsx` (lines 227-238)
+   ```tsx
+   {userId && onAddItem && (
+     <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+       <PhotoAnalysisButton
+         onOpen={handleOpenPhotoAnalysis}
+         onNavigateToSettings={onNavigateToSettings}
+         disabled={!userId || !onAddItem}
+       />
+       <VoiceRecordingButton
+         onOpen={handleOpenVoiceRecording}
+         onNavigateToSettings={onNavigateToSettings}
+         disabled={!userId || !onAddItem}
+       />
+     </div>
+   )}
+   ```
+
+3. **Conditional Rendering**: Since `onAddItem` is `undefined`, the condition `userId && onAddItem` evaluates to `false`, causing the entire section containing both recording buttons to not render.
+
+### Component Dependencies
+- `VoiceRecordingButton` component (`src/components/VoiceRecordingButton.tsx`)
+- `PhotoAnalysisButton` component (`src/components/PhotoAnalysisButton.tsx`)
+- Both components depend on the `onAddItem` prop being passed to `InventoryDashboard`
+
+## Impact
+- **Recording Button**: Completely invisible/not rendered
+- **Photo Analysis Button**: Also affected by the same issue
+- **User Experience**: Users cannot access voice recording or photo analysis features
+- **Functionality**: Core AI-powered features are inaccessible
+
+## Affected Components
+1. `src/pages/Index.tsx` - Missing prop definition
+2. `src/components/InventoryDashboard.tsx` - Conditional rendering logic
+3. `src/components/VoiceRecordingButton.tsx` - Not rendered due to missing prop
+4. `src/components/PhotoAnalysisButton.tsx` - Not rendered due to missing prop
+
+## Fix Required
+Add the missing `onAddItem={addFoodItem}` prop to the `InventoryDashboard` component call in `src/pages/Index.tsx`.
+
+### Before (Lines 544-553)
+```tsx
+<InventoryDashboard
+  foodItems={foodItems}
+  onRemoveItem={removeFoodItem}
+  onEditItem={setEditingItem}
+  userId={user.id}
+  onNavigateToSettings={() => setActiveTab('settings')}
+  recentActions={recentActions}
+  historyLoading={historyLoading}
+  refetchHistory={refetchHistory}
+/>
+```
+
+### After (Proposed Fix)
+```tsx
+<InventoryDashboard
+  foodItems={foodItems}
+  onRemoveItem={removeFoodItem}
+  onEditItem={setEditingItem}
+  onAddItem={addFoodItem}
+  userId={user.id}
+  onNavigateToSettings={() => setActiveTab('settings')}
+  recentActions={recentActions}
+  historyLoading={historyLoading}
+  refetchHistory={refetchHistory}
+/>
+```
+
+## Additional Context
+- The `addFoodItem` function is already available in the `Index.tsx` scope via the `useFoodItems` hook
+- The `InventoryDashboard` component interface expects an optional `onAddItem` prop
+- The fix is minimal and requires only adding one line of code
+
+## Testing Notes
+After applying the fix, both the recording button and photo analysis button should become visible in the dashboard view for authenticated users with proper API token configuration.

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -476,6 +476,7 @@ const Index = () => {
               foodItems={foodItems}
               onRemoveItem={removeFoodItem}
               onEditItem={setEditingItem}
+              onAddItem={addFoodItem}
               userId={user.id}
               onNavigateToSettings={() => setActiveTab('settings')}
               recentActions={recentActions}


### PR DESCRIPTION
Add `onAddItem` prop to `InventoryDashboard` component to restore visibility of recording and photo analysis buttons.