### PR TITLE
Remove duplicates and reposition buttons

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -539,14 +539,6 @@ const Index = () => {
                 <Plus className="w-4 h-4 mr-2" />
                 {activeTab === 'inventory' ? 'Add Food Item' : 'Add Meal Plan'}
               </Button>
-              {activeTab === 'inventory' && (
-                <PhotoAnalysisButton
-                  onOpen={() => setShowPhotoAnalysis(true)}
-                  onNavigateToSettings={() => setActiveTab('settings')}
-                  disabled={!user?.id}
-                  className="w-full sm:w-auto"
-                />
-              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
Remove duplicated photo analysis button to fix UI layout.

The `PhotoAnalysisButton` was incorrectly rendered in `Index.tsx`, causing a duplicate to appear below the recent actions section. The correct positioning of both photo and voice analysis buttons already exists in `InventoryDashboard.tsx`.