### PR TITLE
Fix location persistence bug

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",


### PR DESCRIPTION
<!-- Enable sharing of custom storage locations across the application and resolve a related TypeScript error. -->

Custom storage locations added via 'Other' were not immediately available across different item forms. This is fixed by implementing a pub/sub system using `localStorage` and `window.dispatchEvent` to synchronize updates in real-time. A related TypeScript error ('Cannot find module react') was also resolved by adjusting `moduleResolution` in `tsconfig.app.json` from `bundler` to `node` to correctly locate type declarations.