### PR TITLE
Fix button alignment in meal plan card

### DIFF
--- a/src/components/MealPlanning.tsx
+++ b/src/components/MealPlanning.tsx
@@ -156,7 +156,7 @@ export const MealPlanning = ({
                 </div>
               )}
 
-              <div className="flex justify-end gap-2">
+              <div className="flex flex-wrap justify-end gap-2">
                 <Button
                   variant="outline"
                   size="sm"


### PR DESCRIPTION
Add `flex-wrap` to meal plan card buttons to prevent overflow on mobile.