### PR TITLE
Add toggle for AI recommendations

### DIFF
--- a/src/components/MultiProviderSettings.tsx
+++ b/src/components/MultiProviderSettings.tsx
@@ -197,19 +197,9 @@ const MultiProviderSettings = () => {
                       <div key={provider} className="flex items-center justify-between p-2 border rounded">
                         <span className="text-sm">{AI_PROVIDERS[provider].name}</span>
                         {hasToken ? (
-                          {(() => {
-                            const bp: ComponentProps<typeof Badge> = {
-                              className: cn(badgeVariants({ variant: 'outline' }), 'text-green-600 border-green-600'),
-                            };
-                            return <Badge {...bp}>✓</Badge>;
-                          })()}
+                          <Badge className={cn(badgeVariants({ variant: 'outline' }), 'text-green-600 border-green-600')}>✓</Badge>
                         ) : (
-                          {(() => {
-                            const bp: ComponentProps<typeof Badge> = {
-                              className: cn(badgeVariants({ variant: 'outline' }), 'text-gray-400 border-gray-400'),
-                            };
-                            return <Badge {...bp}>○</Badge>;
-                          })()}
+                          <Badge className={cn(badgeVariants({ variant: 'outline' }), 'text-gray-400 border-gray-400')}>○</Badge>
                         )}
                       </div>
                     );

--- a/src/components/MultiProviderSettings.tsx
+++ b/src/components/MultiProviderSettings.tsx
@@ -16,6 +16,7 @@ import { AIProviderFactory } from '@/lib/ai-providers/factory';
 import UserProfile from './UserProfile';
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
+import type { ComponentProps } from 'react';
 
 type BadgeVariant = VariantProps<typeof badgeVariants>['variant'];
 
@@ -141,7 +142,7 @@ const MultiProviderSettings = () => {
       extraClass = 'text-orange-600 border-orange-600';
     }
 
-    const badgeProps: BadgeProps = {
+    const badgeProps: ComponentProps<typeof Badge> = {
       className: cn(badgeVariants({ variant }), extraClass),
     };
 
@@ -196,9 +197,19 @@ const MultiProviderSettings = () => {
                       <div key={provider} className="flex items-center justify-between p-2 border rounded">
                         <span className="text-sm">{AI_PROVIDERS[provider].name}</span>
                         {hasToken ? (
-                          <Badge className={cn(badgeVariants({ variant: 'outline' }), 'text-green-600 border-green-600')}>✓</Badge>
+                          {(() => {
+                            const bp: ComponentProps<typeof Badge> = {
+                              className: cn(badgeVariants({ variant: 'outline' }), 'text-green-600 border-green-600'),
+                            };
+                            return <Badge {...bp}>✓</Badge>;
+                          })()}
                         ) : (
-                          <Badge className={cn(badgeVariants({ variant: 'outline' }), 'text-gray-400 border-gray-400')}>○</Badge>
+                          {(() => {
+                            const bp: ComponentProps<typeof Badge> = {
+                              className: cn(badgeVariants({ variant: 'outline' }), 'text-gray-400 border-gray-400'),
+                            };
+                            return <Badge {...bp}>○</Badge>;
+                          })()}
                         )}
                       </div>
                     );

--- a/src/components/MultiProviderSettings.tsx
+++ b/src/components/MultiProviderSettings.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
 import { Badge } from '@/components/ui/badge';
+import type { BadgeProps } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Key, Shield, Trash2, Globe, ExternalLink, Bot, Settings as SettingsIcon, Bell } from 'lucide-react';
@@ -111,7 +112,7 @@ const MultiProviderSettings = () => {
     }));
   };
 
-  const getProviderStatusBadge = (provider: AIProvider) => {
+  const getProviderStatusBadge = (provider: AIProvider): React.ReactElement<BadgeProps> => {
     const hasToken = providerTokens[provider];
     const isSelected = selectedProvider === provider;
     

--- a/src/components/MultiProviderSettings.tsx
+++ b/src/components/MultiProviderSettings.tsx
@@ -6,7 +6,6 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
 import { Badge, badgeVariants } from '@/components/ui/badge';
-import type { BadgeProps } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Key, Shield, Trash2, Globe, ExternalLink, Bot, Settings as SettingsIcon, Bell } from 'lucide-react';
@@ -142,7 +141,7 @@ const MultiProviderSettings = () => {
     }
 
     return (
-      <Badge className={cn(badgeVariants({ variant }), extraClass)}>
+      <Badge variant={variant} className={cn(badgeVariants({ variant }), extraClass)}>
         {label}
       </Badge>
     );
@@ -196,9 +195,9 @@ const MultiProviderSettings = () => {
                       <div key={provider} className="flex items-center justify-between p-2 border rounded">
                         <span className="text-sm">{AI_PROVIDERS[provider].name}</span>
                         {hasToken ? (
-                          <Badge className={cn(badgeVariants({ variant: 'outline' }), 'text-green-600 border-green-600')}>✓</Badge>
+                          <Badge variant="outline" className={cn(badgeVariants({ variant: 'outline' }), 'text-green-600 border-green-600')}>✓</Badge>
                         ) : (
-                          <Badge className={cn(badgeVariants({ variant: 'outline' }), 'text-gray-400 border-gray-400')}>○</Badge>
+                          <Badge variant="outline" className={cn(badgeVariants({ variant: 'outline' }), 'text-gray-400 border-gray-400')}>○</Badge>
                         )}
                       </div>
                     );

--- a/src/components/MultiProviderSettings.tsx
+++ b/src/components/MultiProviderSettings.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
+import type { VariantProps } from 'class-variance-authority';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
-import { Badge } from '@/components/ui/badge';
+import { Badge, badgeVariants } from '@/components/ui/badge';
 import type { BadgeProps } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -14,6 +15,8 @@ import { AIProvider, AI_PROVIDERS } from '@/types/aiProvider';
 import { AIProviderFactory } from '@/lib/ai-providers/factory';
 import UserProfile from './UserProfile';
 import { Switch } from '@/components/ui/switch';
+
+type BadgeVariant = VariantProps<typeof badgeVariants>['variant'];
 
 const MultiProviderSettings = () => {
   const { 
@@ -112,7 +115,7 @@ const MultiProviderSettings = () => {
     }));
   };
 
-  const getProviderStatusBadge = (provider: AIProvider): React.ReactElement<BadgeProps> => {
+  const getProviderStatusBadge = (provider: AIProvider) => {
     const hasToken = providerTokens[provider];
     const isSelected = selectedProvider === provider;
     

--- a/src/components/MultiProviderSettings.tsx
+++ b/src/components/MultiProviderSettings.tsx
@@ -5,7 +5,8 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
-import { Badge, badgeVariants, BadgeProps } from '@/components/ui/badge';
+import { Badge, badgeVariants } from '@/components/ui/badge';
+import type { BadgeProps } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Key, Shield, Trash2, Globe, ExternalLink, Bot, Settings as SettingsIcon, Bell } from 'lucide-react';
@@ -195,19 +196,9 @@ const MultiProviderSettings = () => {
                       <div key={provider} className="flex items-center justify-between p-2 border rounded">
                         <span className="text-sm">{AI_PROVIDERS[provider].name}</span>
                         {hasToken ? (
-                          {(() => {
-                            const props: BadgeProps = {
-                              className: cn(badgeVariants({ variant: 'outline' }), 'text-green-600 border-green-600'),
-                            };
-                            return <Badge {...props}>✓</Badge>;
-                          })()}
+                          <Badge className={cn(badgeVariants({ variant: 'outline' }), 'text-green-600 border-green-600')}>✓</Badge>
                         ) : (
-                          {(() => {
-                            const props: BadgeProps = {
-                              className: cn(badgeVariants({ variant: 'outline' }), 'text-gray-400 border-gray-400'),
-                            };
-                            return <Badge {...props}>○</Badge>;
-                          })()}
+                          <Badge className={cn(badgeVariants({ variant: 'outline' }), 'text-gray-400 border-gray-400')}>○</Badge>
                         )}
                       </div>
                     );

--- a/src/components/MultiProviderSettings.tsx
+++ b/src/components/MultiProviderSettings.tsx
@@ -120,8 +120,6 @@ const MultiProviderSettings = () => {
     const hasToken = providerTokens[provider];
     const isSelected = selectedProvider === provider;
 
-    type BadgeVariant = VariantProps<typeof badgeVariants>["variant"];
-
     let variant: BadgeVariant = 'default';
     let label = '';
     let extraClass = '';
@@ -144,7 +142,7 @@ const MultiProviderSettings = () => {
     }
 
     return (
-      <Badge variant={variant} className={cn(extraClass)}>
+      <Badge className={cn(badgeVariants({ variant }), extraClass)}>
         {label}
       </Badge>
     );
@@ -198,9 +196,9 @@ const MultiProviderSettings = () => {
                       <div key={provider} className="flex items-center justify-between p-2 border rounded">
                         <span className="text-sm">{AI_PROVIDERS[provider].name}</span>
                         {hasToken ? (
-                          <Badge variant="outline" className="text-green-600 border-green-600">✓</Badge>
+                          <Badge className={cn(badgeVariants({ variant: 'outline' }), 'text-green-600 border-green-600')}>✓</Badge>
                         ) : (
-                          <Badge variant="outline" className="text-gray-400 border-gray-400">○</Badge>
+                          <Badge className={cn(badgeVariants({ variant: 'outline' }), 'text-gray-400 border-gray-400')}>○</Badge>
                         )}
                       </div>
                     );

--- a/src/components/MultiProviderSettings.tsx
+++ b/src/components/MultiProviderSettings.tsx
@@ -17,8 +17,13 @@ import UserProfile from './UserProfile';
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 import type { ComponentProps } from 'react';
+import React from 'react';
+import { Badge as RawBadge } from '@/components/ui/badge';
 
 type BadgeVariant = VariantProps<typeof badgeVariants>['variant'];
+
+// Locally re-declare Badge with its full prop type so TS keeps className
+const Badge: React.FC<BadgeProps> = RawBadge;
 
 const MultiProviderSettings = () => {
   const { 

--- a/src/components/MultiProviderSettings.tsx
+++ b/src/components/MultiProviderSettings.tsx
@@ -15,6 +15,7 @@ import { AIProvider, AI_PROVIDERS } from '@/types/aiProvider';
 import { AIProviderFactory } from '@/lib/ai-providers/factory';
 import UserProfile from './UserProfile';
 import { Switch } from '@/components/ui/switch';
+import { cn } from '@/lib/utils';
 
 type BadgeVariant = VariantProps<typeof badgeVariants>['variant'];
 
@@ -118,14 +119,35 @@ const MultiProviderSettings = () => {
   const getProviderStatusBadge = (provider: AIProvider) => {
     const hasToken = providerTokens[provider];
     const isSelected = selectedProvider === provider;
-    
+
+    type BadgeVariant = VariantProps<typeof badgeVariants>["variant"];
+
+    let variant: BadgeVariant = 'default';
+    let label = '';
+    let extraClass = '';
+
     if (isSelected && hasToken) {
-      return <Badge className="bg-green-600 text-white border-green-600">Active</Badge>;
+      // Active provider with a saved token
+      variant = 'default';
+      label = 'Active';
+      extraClass = 'bg-green-600 text-white border-green-600';
     } else if (hasToken) {
-      return <Badge variant="outline" className="text-blue-600 border-blue-600">Configured</Badge>;
+      // Provider has a token but isn\'t the active one
+      variant = 'outline';
+      label = 'Configured';
+      extraClass = 'text-blue-600 border-blue-600';
     } else {
-      return <Badge variant="outline" className="text-orange-600 border-orange-600">Not Set</Badge>;
+      // No token stored yet
+      variant = 'outline';
+      label = 'Not Set';
+      extraClass = 'text-orange-600 border-orange-600';
     }
+
+    return (
+      <Badge variant={variant} className={cn(extraClass)}>
+        {label}
+      </Badge>
+    );
   };
 
   return (

--- a/src/components/MultiProviderSettings.tsx
+++ b/src/components/MultiProviderSettings.tsx
@@ -1,12 +1,11 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect, type ComponentProps } from 'react';
 import type { VariantProps } from 'class-variance-authority';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
-import { Badge, badgeVariants } from '@/components/ui/badge';
-import type { BadgeProps } from '@/components/ui/badge';
+import { Badge as BadgeBase, badgeVariants, type BadgeProps } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Key, Shield, Trash2, Globe, ExternalLink, Bot, Settings as SettingsIcon, Bell } from 'lucide-react';
@@ -16,14 +15,11 @@ import { AIProviderFactory } from '@/lib/ai-providers/factory';
 import UserProfile from './UserProfile';
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
-import type { ComponentProps } from 'react';
-import React from 'react';
-import { Badge as RawBadge } from '@/components/ui/badge';
 
 type BadgeVariant = VariantProps<typeof badgeVariants>['variant'];
 
-// Locally re-declare Badge with its full prop type so TS keeps className
-const Badge: React.FC<BadgeProps> = RawBadge;
+// Local alias with proper props
+const Badge: React.FC<BadgeProps> = BadgeBase as React.FC<BadgeProps>;
 
 const MultiProviderSettings = () => {
   const { 

--- a/src/components/MultiProviderSettings.tsx
+++ b/src/components/MultiProviderSettings.tsx
@@ -7,11 +7,12 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Key, Shield, Trash2, Globe, ExternalLink, Bot, Settings as SettingsIcon } from 'lucide-react';
+import { Key, Shield, Trash2, Globe, ExternalLink, Bot, Settings as SettingsIcon, Bell } from 'lucide-react';
 import { useApiTokens } from '@/hooks/useApiTokens';
 import { AIProvider, AI_PROVIDERS } from '@/types/aiProvider';
 import { AIProviderFactory } from '@/lib/ai-providers/factory';
 import UserProfile from './UserProfile';
+import { Switch } from '@/components/ui/switch';
 
 const MultiProviderSettings = () => {
   const { 
@@ -23,6 +24,8 @@ const MultiProviderSettings = () => {
     getLanguage, 
     saveLanguage,
     hasAnyToken,
+    aiRecommendationsEnabled,
+    saveAiRecommendationsEnabled,
   } = useApiTokens();
 
   const [tokens, setTokens] = useState<Record<string, string>>({});
@@ -31,6 +34,7 @@ const MultiProviderSettings = () => {
   const [isSaving, setIsSaving] = useState<Record<string, boolean>>({});
   const [isRemoving, setIsRemoving] = useState<Record<string, boolean>>({});
   const [isSavingLanguage, setIsSavingLanguage] = useState(false);
+  const [isSavingAiPref, setIsSavingAiPref] = useState(false);
   const [activeTab, setActiveTab] = useState('providers');
 
   const supportedProviders = AIProviderFactory.getSupportedProviders();
@@ -80,6 +84,12 @@ const MultiProviderSettings = () => {
     setIsSavingLanguage(true);
     await saveLanguage(selectedLanguage);
     setIsSavingLanguage(false);
+  };
+
+  const handleToggleAiRecommendations = async (enabled: boolean) => {
+    setIsSavingAiPref(true);
+    await saveAiRecommendationsEnabled(enabled);
+    setIsSavingAiPref(false);
   };
 
   const handleRemoveToken = async (provider: AIProvider) => {
@@ -247,6 +257,31 @@ const MultiProviderSettings = () => {
                   ))}
                 </SelectContent>
               </Select>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Bell className="w-5 h-5" />
+                AI Recommendations
+              </CardTitle>
+              <CardDescription>
+                Enable or disable AI-powered recommendations in the dashboard to
+                avoid unintended usage.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex items-center gap-4">
+                <Switch
+                  checked={aiRecommendationsEnabled}
+                  onCheckedChange={handleToggleAiRecommendations}
+                  disabled={isSavingAiPref}
+                />
+                <span className="text-sm text-muted-foreground">
+                  {aiRecommendationsEnabled ? 'Enabled' : 'Disabled'}
+                </span>
+              </div>
             </CardContent>
           </Card>
         </TabsContent>

--- a/src/components/MultiProviderSettings.tsx
+++ b/src/components/MultiProviderSettings.tsx
@@ -23,7 +23,6 @@ const MultiProviderSettings = () => {
     removeTokenForProvider, 
     getLanguage, 
     saveLanguage,
-    hasAnyToken,
     aiRecommendationsEnabled,
     saveAiRecommendationsEnabled,
   } = useApiTokens();

--- a/src/components/MultiProviderSettings.tsx
+++ b/src/components/MultiProviderSettings.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
-import { Badge, badgeVariants } from '@/components/ui/badge';
+import { Badge, badgeVariants, BadgeProps } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Key, Shield, Trash2, Globe, ExternalLink, Bot, Settings as SettingsIcon, Bell } from 'lucide-react';
@@ -140,11 +140,11 @@ const MultiProviderSettings = () => {
       extraClass = 'text-orange-600 border-orange-600';
     }
 
-    return (
-      <Badge className={cn(badgeVariants({ variant }), extraClass)}>
-        {label}
-      </Badge>
-    );
+    const badgeProps: BadgeProps = {
+      className: cn(badgeVariants({ variant }), extraClass),
+    };
+
+    return <Badge {...badgeProps}>{label}</Badge>;
   };
 
   return (
@@ -195,9 +195,19 @@ const MultiProviderSettings = () => {
                       <div key={provider} className="flex items-center justify-between p-2 border rounded">
                         <span className="text-sm">{AI_PROVIDERS[provider].name}</span>
                         {hasToken ? (
-                          <Badge className={cn(badgeVariants({ variant: 'outline' }), 'text-green-600 border-green-600')}>✓</Badge>
+                          {(() => {
+                            const props: BadgeProps = {
+                              className: cn(badgeVariants({ variant: 'outline' }), 'text-green-600 border-green-600'),
+                            };
+                            return <Badge {...props}>✓</Badge>;
+                          })()}
                         ) : (
-                          <Badge className={cn(badgeVariants({ variant: 'outline' }), 'text-gray-400 border-gray-400')}>○</Badge>
+                          {(() => {
+                            const props: BadgeProps = {
+                              className: cn(badgeVariants({ variant: 'outline' }), 'text-gray-400 border-gray-400'),
+                            };
+                            return <Badge {...props}>○</Badge>;
+                          })()}
                         )}
                       </div>
                     );

--- a/src/components/MultiProviderSettings.tsx
+++ b/src/components/MultiProviderSettings.tsx
@@ -141,7 +141,7 @@ const MultiProviderSettings = () => {
     }
 
     return (
-      <Badge variant={variant} className={cn(badgeVariants({ variant }), extraClass)}>
+      <Badge className={cn(badgeVariants({ variant }), extraClass)}>
         {label}
       </Badge>
     );
@@ -195,9 +195,9 @@ const MultiProviderSettings = () => {
                       <div key={provider} className="flex items-center justify-between p-2 border rounded">
                         <span className="text-sm">{AI_PROVIDERS[provider].name}</span>
                         {hasToken ? (
-                          <Badge variant="outline" className={cn(badgeVariants({ variant: 'outline' }), 'text-green-600 border-green-600')}>✓</Badge>
+                          <Badge className={cn(badgeVariants({ variant: 'outline' }), 'text-green-600 border-green-600')}>✓</Badge>
                         ) : (
-                          <Badge variant="outline" className={cn(badgeVariants({ variant: 'outline' }), 'text-gray-400 border-gray-400')}>○</Badge>
+                          <Badge className={cn(badgeVariants({ variant: 'outline' }), 'text-gray-400 border-gray-400')}>○</Badge>
                         )}
                       </div>
                     );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -22,6 +22,7 @@ import { FoodItem, MealPlan } from '@/types';
 import { AIRecommendations } from '@/components/AIRecommendations';
 import { useAIRecommendations } from '@/hooks/useAIRecommendations';
 import { toast } from '@/hooks/use-toast';
+import { useApiTokens } from '@/hooks/useApiTokens';
 
 const Index = () => {
   const { user, loading: authLoading, signOut } = useAuth();
@@ -38,6 +39,7 @@ const Index = () => {
   const { foodItems, loading: foodLoading, addFoodItem, updateFoodItem, removeFoodItem } = useFoodItems(user?.id, undefined, refetchHistory);
   const { mealPlans, loading: mealLoading, addMealPlan, updateMealPlan, removeMealPlan } = useMealPlans(user?.id);
   const { updateConsumptionPattern, updateMealCombination } = useAIRecommendations(user?.id, foodItems, recentActions);
+  const { aiRecommendationsEnabled } = useApiTokens();
 
   useEffect(() => {
     const tab = searchParams.get('tab');
@@ -510,7 +512,7 @@ const Index = () => {
         });
       }
     });
-    setShowBulkPhotoAnalysis(false);
+    setShowPhotoAnalysis(false);
   };
 
   const handleVoiceRecordingComplete = (items: Omit<FoodItem, 'id' | 'userId'>[]) => {
@@ -535,7 +537,7 @@ const Index = () => {
         return (
           <div className="space-y-6">
             {/* AI Recommendations Section */}
-            {user?.id && (
+            {user?.id && aiRecommendationsEnabled && (
               <AIRecommendations
                 userId={user.id}
                 onAddToShoppingList={(items) => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -38,7 +38,7 @@ const Index = () => {
   const { recentActions, loading: historyLoading, refetch: refetchHistory } = useActionHistory(user?.id);
   const { foodItems, loading: foodLoading, addFoodItem, updateFoodItem, removeFoodItem } = useFoodItems(user?.id, undefined, refetchHistory);
   const { mealPlans, loading: mealLoading, addMealPlan, updateMealPlan, removeMealPlan } = useMealPlans(user?.id);
-  const { updateConsumptionPattern, updateMealCombination } = useAIRecommendations(user?.id, foodItems, recentActions);
+  const { updateConsumptionPattern, updateMealCombination } = useAIRecommendations(user?.id);
   const { aiRecommendationsEnabled } = useApiTokens();
 
   useEffect(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
       "@/*": ["./src/*"]
     },
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "types": ["vite/client", "react", "react-dom", "date-fns"],
     "noImplicitAny": false,
     "noUnusedParameters": false,


### PR DESCRIPTION
Add a dashboard control to enable/disable AI recommendations to prevent unintended token usage.

This PR introduces a new user preference `aiRecommendationsEnabled` managed by the `useApiTokens` hook, allowing users to toggle AI recommendations on or off. A corresponding switch has been added to the `MultiProviderSettings` UI. The `Index.tsx` component now conditionally renders the `AIRecommendations` section based on this preference. Additionally, various type and linter errors, including `Badge` component prop typing and `React` module resolution, have been resolved to ensure code quality.