### PR TITLE
Make toaster dismissable by swipe

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -47,6 +47,8 @@ const Toast = React.forwardRef<
     <ToastPrimitives.Root
       ref={ref}
       className={cn(toastVariants({ variant }), className)}
+      swipeDirection="right"
+      swipeThreshold={50}
       {...props}
     />
   )


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable toast notifications to be dismissed by swiping right.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This leverages Radix UI's built-in swipe functionality by setting the `swipeDirection` and `swipeThreshold` props on the `Toast` component.