### PR TITLE
Fix ai recommendations display issues

### DIFF
--- a/src/components/AIRecommendations.tsx
+++ b/src/components/AIRecommendations.tsx
@@ -13,16 +13,18 @@ interface AIRecommendationsProps {
   userId: string;
   onAddToShoppingList?: (items: { name: string; quantity: number; unit: string }[]) => void;
   onRefreshRecommendations?: () => Promise<void>;
+  forceRefresh?: boolean;
 }
 
 export const AIRecommendations = ({ 
   userId, 
   onAddToShoppingList,
-  onRefreshRecommendations
+  onRefreshRecommendations,
+  forceRefresh = false
 }: AIRecommendationsProps) => {
-  console.log('AIRecommendations component rendered with userId:', userId);
+  console.log('AIRecommendations component rendered with userId:', userId, 'forceRefresh:', forceRefresh);
   
-  const { recommendations, loading, refreshRecommendations } = useAIRecommendations(userId);
+  const { recommendations, loading, refreshRecommendations } = useAIRecommendations(userId, forceRefresh);
   const { toast } = useToast();
   
   console.log('AIRecommendations hook result:', { recommendations, loading });

--- a/src/components/DashboardWindow.tsx
+++ b/src/components/DashboardWindow.tsx
@@ -34,6 +34,14 @@ export const DashboardWindow: React.FC<DashboardWindowProps> = ({
   const [isMinimized, setIsMinimized] = useState(false);
   const [windowElement, setWindowElement] = useState<HTMLDivElement | null>(null);
 
+  // Refresh recommendations when modal opens
+  useEffect(() => {
+    if (isOpen && userId && onRefreshRecommendations) {
+      console.log('DashboardWindow: Modal opened, refreshing recommendations');
+      onRefreshRecommendations();
+    }
+  }, [isOpen, userId, onRefreshRecommendations]);
+
   useEffect(() => {
     if (isOpen) {
       const newWindow = document.createElement('div');
@@ -131,6 +139,7 @@ export const DashboardWindow: React.FC<DashboardWindowProps> = ({
               <AIRecommendations 
                 userId={userId} 
                 onRefreshRecommendations={onRefreshRecommendations}
+                forceRefresh={true}
               />
             </div>
           )}

--- a/src/hooks/useAIRecommendations.tsx
+++ b/src/hooks/useAIRecommendations.tsx
@@ -55,7 +55,7 @@ interface AIRecommendations {
   generatedAt: Date;
 }
 
-export const useAIRecommendations = (userId: string | undefined) => {
+export const useAIRecommendations = (userId: string | undefined, forceRefresh: boolean = false) => {
   const [recommendations, setRecommendations] = useState<AIRecommendations | null>(null);
   const [loading, setLoading] = useState(false);
   const { toast } = useToast();
@@ -356,6 +356,13 @@ export const useAIRecommendations = (userId: string | undefined) => {
   // Load cached recommendations if available and recent
   const loadCachedRecommendations = async () => {
     if (!userId) return;
+
+    // If forceRefresh is true, skip cache and generate fresh recommendations
+    if (forceRefresh) {
+      console.log('Force refresh enabled, skipping cache');
+      generateRecommendations();
+      return;
+    }
 
     try {
       const { data: cachedRecommendations, error } = await supabase

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -592,14 +592,6 @@ const Index = () => {
       case 'inventory':
         return (
           <div className="space-y-6">
-            {/* AI Recommendations Section */}
-            {aiRecommendationsEnabled && user.id && (
-              <AIRecommendations 
-                userId={user.id} 
-                onRefreshRecommendations={refreshRecommendations}
-              />
-            )}
-            
             <InventoryDashboard
               foodItems={foodItems}
               onRemoveItem={handleRemoveFoodItem}


### PR DESCRIPTION
Fixes AI recommendations appearing on the main dashboard and ensures fresh data loads in the "view details" modal.

This PR addresses two issues:
1. AI recommendations were incorrectly rendered on the main dashboard in addition to the "view details" modal.
2. Recommendations in the "view details" modal were empty because the `useAIRecommendations` hook was sharing state with the main dashboard instance, preventing a fresh data fetch when the modal opened.