### PR TITLE
Update ai recommendations on inventory changes

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -39,9 +39,9 @@ const Index = () => {
   const [dashboardData, setDashboardData] = useState<any>(null);
 
   const { recentActions, loading: historyLoading, refetch: refetchHistory } = useActionHistory(user?.id);
-  const { foodItems, loading: foodLoading, addFoodItem, updateFoodItem, removeFoodItem } = useFoodItems(user?.id, undefined, refetchHistory);
+  const { updateConsumptionPattern, updateMealCombination, clearCacheOnInventoryChange } = useAIRecommendations(user?.id);
+  const { foodItems, loading: foodLoading, addFoodItem, updateFoodItem, removeFoodItem } = useFoodItems(user?.id, clearCacheOnInventoryChange, refetchHistory);
   const { mealPlans, loading: mealLoading, addMealPlan, updateMealPlan, removeMealPlan } = useMealPlans(user?.id);
-  const { updateConsumptionPattern, updateMealCombination } = useAIRecommendations(user?.id);
   const { aiRecommendationsEnabled } = useApiTokens();
 
   // Dashboard window event listener
@@ -490,6 +490,9 @@ const Index = () => {
     
     // Remove from meal plans
     removeMealPlan(meal.id);
+    
+    // Clear AI recommendations cache to force refresh
+    clearCacheOnInventoryChange();
   };
 
   const handleOpenPhotoAnalysis = () => {
@@ -512,6 +515,9 @@ const Index = () => {
       });
     }
     
+    // Clear AI recommendations cache to force refresh
+    clearCacheOnInventoryChange();
+    
     setShowPhotoAnalysis(false);
   };
 
@@ -528,6 +534,10 @@ const Index = () => {
         });
       }
     });
+    
+    // Clear AI recommendations cache to force refresh
+    clearCacheOnInventoryChange();
+    
     setShowPhotoAnalysis(false);
   };
 
@@ -544,6 +554,10 @@ const Index = () => {
         });
       }
     });
+    
+    // Clear AI recommendations cache to force refresh
+    clearCacheOnInventoryChange();
+    
     setShowVoiceRecording(false);
   };
 


### PR DESCRIPTION
Refresh AI recommendations when inventory items are added, removed, or updated to ensure data consistency.

Previously, AI recommendations were not refreshed when inventory items were modified because the `onActionComplete` callback in `useFoodItems` was not utilized, and other direct modification handlers also lacked a cache invalidation trigger.