### PR TITLE
Fix date validation in getFreshInventory

### DIFF
--- a/src/hooks/useFoodItems.tsx
+++ b/src/hooks/useFoodItems.tsx
@@ -3,6 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { FoodItem, FoodItemLabel } from '@/types';
 import { toast } from '@/hooks/use-toast';
 import { useActionHistory } from '@/hooks/useActionHistory';
+import { parseSafeDate } from '@/utils/dateUtils';
 
 export const useFoodItems = (userId: string | undefined, onActionComplete?: () => void, refetchActions?: () => void) => {
   const [foodItems, setFoodItems] = useState<FoodItem[]>([]);
@@ -28,8 +29,8 @@ export const useFoodItems = (userId: string | undefined, onActionComplete?: () =
       const transformedItems: FoodItem[] = data.map(item => ({
         id: item.id,
         name: item.name,
-        dateCookedStored: new Date(item.date_cooked_stored),
-        eatByDate: new Date(item.eat_by_date),
+        dateCookedStored: parseSafeDate(item.date_cooked_stored),
+        eatByDate: parseSafeDate(item.eat_by_date),
         amount: item.amount || 1, // Default to 1 if not set
         unit: item.unit || 'item', // Default to 'item' if not set
         storageLocation: item.storage_location,
@@ -77,8 +78,8 @@ export const useFoodItems = (userId: string | undefined, onActionComplete?: () =
       const newItem: FoodItem = {
         id: data.id,
         name: data.name,
-        dateCookedStored: new Date(data.date_cooked_stored),
-        eatByDate: new Date(data.eat_by_date),
+        dateCookedStored: parseSafeDate(data.date_cooked_stored),
+        eatByDate: parseSafeDate(data.eat_by_date),
         amount: data.amount,
         unit: data.unit,
         storageLocation: data.storage_location,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -29,6 +29,7 @@ import { ActionHistoryItem } from '@/hooks/useActionHistory';
 import { RecipeGenerator } from '@/components/RecipeGenerator';
 import { MealPlanVoiceRecordingButton } from '@/components/MealPlanVoiceRecordingButton';
 import { MealPlanVoiceRecording } from '@/components/MealPlanVoiceRecording';
+import { parseSafeDate } from '@/utils/dateUtils';
 
 const Index = () => {
   const { user, loading: authLoading, signOut } = useAuth();
@@ -581,12 +582,12 @@ const Index = () => {
         return foodItems; // Fallback to current state
       }
 
-      // Transform the data to match FoodItem format
+      // Transform the data to match FoodItem format with safe date parsing
       const freshItems: FoodItem[] = data.map(item => ({
         id: item.id,
         name: item.name,
-        dateCookedStored: new Date(item.date_cooked_stored),
-        eatByDate: new Date(item.eat_by_date),
+        dateCookedStored: parseSafeDate(item.date_cooked_stored),
+        eatByDate: parseSafeDate(item.eat_by_date),
         amount: item.amount || 1,
         unit: item.unit || 'item',
         storageLocation: item.storage_location,

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,47 @@
+/**
+ * Safely parses date values from database or user input
+ * Handles null, undefined, malformed strings, and invalid dates
+ * @param dateValue - The date value to parse (can be string, Date, null, undefined, etc.)
+ * @returns A valid Date object, defaults to current date if parsing fails
+ */
+export const parseSafeDate = (dateValue: any): Date => {
+  // Handle null, undefined, or empty values
+  if (!dateValue) {
+    return new Date(); // Default to current date
+  }
+  
+  // Handle string values
+  if (typeof dateValue === 'string') {
+    const trimmed = dateValue.trim();
+    if (!trimmed) {
+      return new Date(); // Default to current date for empty strings
+    }
+    
+    const parsed = new Date(trimmed);
+    // Check if the parsed date is valid
+    if (isNaN(parsed.getTime())) {
+      console.warn(`Invalid date value: ${dateValue}, using current date as fallback`);
+      return new Date(); // Default to current date for invalid dates
+    }
+    
+    return parsed;
+  }
+  
+  // Handle Date objects
+  if (dateValue instanceof Date) {
+    if (isNaN(dateValue.getTime())) {
+      console.warn('Invalid Date object, using current date as fallback');
+      return new Date();
+    }
+    return dateValue;
+  }
+  
+  // For any other type, try to create a Date object
+  const parsed = new Date(dateValue);
+  if (isNaN(parsed.getTime())) {
+    console.warn(`Unable to parse date value: ${dateValue}, using current date as fallback`);
+    return new Date();
+  }
+  
+  return parsed;
+};


### PR DESCRIPTION
Implement robust date parsing to prevent `Invalid Date` issues from malformed database values.

The `getFreshInventory` function and other date parsing logic were creating `Date` objects from `item.date_cooked_stored` and `item.eat_by_date` without validation. This led to `Invalid Date` objects for malformed/undefined values or `January 1, 1970` for nulls, causing incorrect date calculations, comparisons, and expiration checks. This PR introduces a shared `parseSafeDate` utility to handle these edge cases gracefully.