### PR TITLE
Fix date parsing bug in inventory management

### DIFF
--- a/src/hooks/useFoodItems.tsx
+++ b/src/hooks/useFoodItems.tsx
@@ -3,7 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { FoodItem, FoodItemLabel } from '@/types';
 import { toast } from '@/hooks/use-toast';
 import { useActionHistory } from '@/hooks/useActionHistory';
-import { parseSafeDate } from '@/utils/dateUtils';
+import { parseSafeDate, parseEatByDate, parseDateCookedStored } from '@/utils/dateUtils';
 
 export const useFoodItems = (userId: string | undefined, onActionComplete?: () => void, refetchActions?: () => void) => {
   const [foodItems, setFoodItems] = useState<FoodItem[]>([]);
@@ -29,8 +29,8 @@ export const useFoodItems = (userId: string | undefined, onActionComplete?: () =
       const transformedItems: FoodItem[] = data.map(item => ({
         id: item.id,
         name: item.name,
-        dateCookedStored: parseSafeDate(item.date_cooked_stored),
-        eatByDate: parseSafeDate(item.eat_by_date),
+        dateCookedStored: parseDateCookedStored(item.date_cooked_stored),
+        eatByDate: parseEatByDate(item.eat_by_date),
         amount: item.amount || 1, // Default to 1 if not set
         unit: item.unit || 'item', // Default to 'item' if not set
         storageLocation: item.storage_location,
@@ -78,8 +78,8 @@ export const useFoodItems = (userId: string | undefined, onActionComplete?: () =
       const newItem: FoodItem = {
         id: data.id,
         name: data.name,
-        dateCookedStored: parseSafeDate(data.date_cooked_stored),
-        eatByDate: parseSafeDate(data.eat_by_date),
+        dateCookedStored: parseDateCookedStored(data.date_cooked_stored),
+        eatByDate: parseEatByDate(data.eat_by_date),
         amount: data.amount,
         unit: data.unit,
         storageLocation: data.storage_location,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -29,7 +29,7 @@ import { ActionHistoryItem } from '@/hooks/useActionHistory';
 import { RecipeGenerator } from '@/components/RecipeGenerator';
 import { MealPlanVoiceRecordingButton } from '@/components/MealPlanVoiceRecordingButton';
 import { MealPlanVoiceRecording } from '@/components/MealPlanVoiceRecording';
-import { parseSafeDate } from '@/utils/dateUtils';
+import { parseSafeDate, parseEatByDate, parseDateCookedStored } from '@/utils/dateUtils';
 
 const Index = () => {
   const { user, loading: authLoading, signOut } = useAuth();
@@ -586,8 +586,8 @@ const Index = () => {
       const freshItems: FoodItem[] = data.map(item => ({
         id: item.id,
         name: item.name,
-        dateCookedStored: parseSafeDate(item.date_cooked_stored),
-        eatByDate: parseSafeDate(item.eat_by_date),
+        dateCookedStored: parseDateCookedStored(item.date_cooked_stored),
+        eatByDate: parseEatByDate(item.eat_by_date),
         amount: item.amount || 1,
         unit: item.unit || 'item',
         storageLocation: item.storage_location,

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -2,26 +2,27 @@
  * Safely parses date values from database or user input
  * Handles null, undefined, malformed strings, and invalid dates
  * @param dateValue - The date value to parse (can be string, Date, null, undefined, etc.)
- * @returns A valid Date object, defaults to current date if parsing fails
+ * @param context - The context in which the date is being used to determine appropriate defaults
+ * @returns A valid Date object with context-specific defaults if parsing fails
  */
-export const parseSafeDate = (dateValue: any): Date => {
+export const parseSafeDate = (dateValue: any, context: 'eatByDate' | 'dateCookedStored' | 'general' = 'general'): Date => {
   // Handle null, undefined, or empty values
   if (!dateValue) {
-    return new Date(); // Default to current date
+    return getContextDefault(context);
   }
   
   // Handle string values
   if (typeof dateValue === 'string') {
     const trimmed = dateValue.trim();
     if (!trimmed) {
-      return new Date(); // Default to current date for empty strings
+      return getContextDefault(context);
     }
     
     const parsed = new Date(trimmed);
     // Check if the parsed date is valid
     if (isNaN(parsed.getTime())) {
-      console.warn(`Invalid date value: ${dateValue}, using current date as fallback`);
-      return new Date(); // Default to current date for invalid dates
+      console.warn(`Invalid date value: ${dateValue}, using context-specific default for ${context}`);
+      return getContextDefault(context);
     }
     
     return parsed;
@@ -30,8 +31,8 @@ export const parseSafeDate = (dateValue: any): Date => {
   // Handle Date objects
   if (dateValue instanceof Date) {
     if (isNaN(dateValue.getTime())) {
-      console.warn('Invalid Date object, using current date as fallback');
-      return new Date();
+      console.warn(`Invalid Date object, using context-specific default for ${context}`);
+      return getContextDefault(context);
     }
     return dateValue;
   }
@@ -39,9 +40,53 @@ export const parseSafeDate = (dateValue: any): Date => {
   // For any other type, try to create a Date object
   const parsed = new Date(dateValue);
   if (isNaN(parsed.getTime())) {
-    console.warn(`Unable to parse date value: ${dateValue}, using current date as fallback`);
-    return new Date();
+    console.warn(`Unable to parse date value: ${dateValue}, using context-specific default for ${context}`);
+    return getContextDefault(context);
   }
   
   return parsed;
+};
+
+/**
+ * Gets context-specific default dates for different use cases
+ * @param context - The context in which the date is being used
+ * @returns A Date object appropriate for the given context
+ */
+const getContextDefault = (context: 'eatByDate' | 'dateCookedStored' | 'general'): Date => {
+  const now = new Date();
+  
+  switch (context) {
+    case 'eatByDate':
+      // Default to 7 days in the future to prevent false expiration alerts
+      // This gives users time to notice and handle the item
+      return new Date(now.getTime() + (7 * 24 * 60 * 60 * 1000));
+    
+    case 'dateCookedStored':
+      // Default to 1 day ago since it represents when food was cooked/stored
+      // This is more realistic than defaulting to today
+      return new Date(now.getTime() - (24 * 60 * 60 * 1000));
+    
+    case 'general':
+    default:
+      // Default to current date for general use cases
+      return now;
+  }
+};
+
+/**
+ * Parses a date specifically for eatByDate context
+ * @param dateValue - The date value to parse
+ * @returns A valid Date object, defaults to 7 days in the future if parsing fails
+ */
+export const parseEatByDate = (dateValue: any): Date => {
+  return parseSafeDate(dateValue, 'eatByDate');
+};
+
+/**
+ * Parses a date specifically for dateCookedStored context
+ * @param dateValue - The date value to parse
+ * @returns A valid Date object, defaults to 1 day ago if parsing fails
+ */
+export const parseDateCookedStored = (dateValue: any): Date => {
+  return parseSafeDate(dateValue, 'dateCookedStored');
 };


### PR DESCRIPTION
Implement context-specific date defaults in `parseSafeDate` to fix incorrect food inventory dates.