### PR TITLE
Fix conflicting CSS class definitions

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -202,13 +202,14 @@
   /* Landing page specific animations */
   .animate-on-scroll {
     opacity: 0;
-    transform: translateY(40px);
-    transition: all 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+    transform: translateY(50px) translateZ(0);
+    transition: all 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    will-change: opacity, transform;
   }
 
   .animate-on-scroll.in-view {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) translateZ(0);
   }
 
   /* Staggered animation delays */
@@ -289,26 +290,7 @@
   }
 }
 
-/* Enhanced intersection observer triggered animations */
-.animate-on-scroll {
-  opacity: 0;
-  transform: translateY(50px) translateZ(0);
-  transition: all 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  will-change: opacity, transform;
-}
 
-.animate-on-scroll.in-view {
-  opacity: 1;
-  transform: translateY(0) translateZ(0);
-}
-
-/* Staggered animation delays for elements */
-.animate-on-scroll:nth-child(1) { transition-delay: 0ms; }
-.animate-on-scroll:nth-child(2) { transition-delay: 100ms; }
-.animate-on-scroll:nth-child(3) { transition-delay: 200ms; }
-.animate-on-scroll:nth-child(4) { transition-delay: 300ms; }
-.animate-on-scroll:nth-child(5) { transition-delay: 400ms; }
-.animate-on-scroll:nth-child(6) { transition-delay: 500ms; }
 
 /* Feature card enhanced hover effects */
 .feature-card {


### PR DESCRIPTION
Consolidate duplicate `.animate-on-scroll` CSS definitions to resolve conflicting animation properties and ensure predictable behavior.