### PR TITLE
Fix recipe cook button app crash

### DIFF
--- a/src/components/SavedRecipes.tsx
+++ b/src/components/SavedRecipes.tsx
@@ -514,7 +514,18 @@ export const SavedRecipes = ({ isOpen, onClose, onAddMealPlan }: SavedRecipesPro
       </DialogContent>
       {showCookModal && mealPlanDraft && (
         <EditMealPlanForm
-          item={{ ...mealPlanDraft, id: '', userId: '' }}
+          // EditMealPlanForm expects a full MealPlan object, so we provide dummy id and userId.
+          // These will be stripped out before saving, and are not used in the form logic.
+          item={{
+            ...mealPlanDraft,
+            id: 'TEMP_ID', // Dummy value, not used
+            userId: 'TEMP_USER', // Dummy value, not used
+            // Defensive: ensure ingredients are present and quantities are numbers
+            ingredients: mealPlanDraft.ingredients?.map(ing => ({
+              ...ing,
+              quantity: typeof ing.quantity === 'number' ? ing.quantity : Number(ing.quantity) || 1,
+            })) || [],
+          }}
           onSubmit={handleCookSubmit}
           onClose={() => { setShowCookModal(false); setMealPlanDraft(null); }}
         />


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Ensure meal plan object passed to edit form has correct types and fields to fix app crash on 'Cook' button.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The crash occurred because the `EditMealPlanForm` expected a fully typed `MealPlan` object, but the conversion from a `Recipe` could result in missing or incorrectly typed fields, particularly for `ingredients` and their `quantity`. This PR adds defensive checks to ensure all required fields are present and `quantity` is always a number, preventing runtime errors.